### PR TITLE
Fix typo in template after linting change

### DIFF
--- a/scripts/dumpJobs.js
+++ b/scripts/dumpJobs.js
@@ -49,11 +49,7 @@ Promise.map(['inactive', 'active', 'failed', 'complete', 'delayed'], state => qu
               setVal(res, key2, val);
             }
           } else {
-            // TODO: Double check the intent of the template here.
-            // The value was: `${key2 }|` with an extra space; eslint complains, justifiably so
-            // Should the space remain (moved after the end curly brace) or was it a redundant
-            // and unnecessary space?
-            crush(val, `${key2} |`, key === 'progress_data' ? 'count' : '');
+            crush(val, `${key2}|`, key === 'progress_data' ? 'count' : '');
           }
         });
       }(job, ''));


### PR DESCRIPTION
Followup to https://github.com/kartotherian/tilerator/pull/17 fixing a leftover typo from the linting when changing from strings to templates.