### PR TITLE
Update tileshell for new Core configuration

### DIFF
--- a/scripts/tileshell.js
+++ b/scripts/tileshell.js
@@ -175,7 +175,7 @@ if (args.dumptiles) {
 
 tilerator.bootstrap(app).then(() => {
   const sources = new core.Sources();
-  return sources.init(app.conf.variables, app.conf.sources);
+  return sources.init(app.conf);
 }).then((sources) => {
   core.setSources(sources);
   if (args.j) {


### PR DESCRIPTION
Some time ago, sources.init() was changed to receive a single "conf" object and extract variables, sources, and request handlers from it.

kartotherian and tilerator were updated to pass in the conf object but tileshell was not updated. It has been failing in production for some time.

Bug: https://phabricator.wikimedia.org/T191807