### PR TITLE
Fix error handling

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -135,7 +135,9 @@ function wrapRouteHandlers(router) {
  * @param {Application} app the application object to add the handler to
  */
 function setErrorHandler(app) {
-  app.use((err, req, res) => {
+  // Note: the 'next' parameter is required for correct error handling
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, req, res, next) => {
     let errObj;
     // ensure this is an HTTPError object
     if (err.constructor === HTTPError) {


### PR DESCRIPTION
Error-handling functions in Express apps take four parameters (err, req,
res, next).[1]  Omitting the 'next' param breaks error handling.

Example:

http://localhost:16535/foo

Expected: "Cannot GET /foo"

Actual: "TypeError: res.status is not a function
    		at app.use (/Users/mholloway/tilerator/lib/util.js:210:9)
    		[...]"

This patch restores the 'next' param and gets error handling working again.

[1] https://expressjs.com/en/guide/error-handling.html#writing-error-handlers