### PR TITLE
TileratorUI: Provide regexes for area-targeted tile bans in Varnish

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -118,7 +118,10 @@
 <script src="leaflet/leaflet.js"></script>
 <!-- Optional - changes URL to reflect the current location on the map -->
 <script src="lib/leaflet-hash.js"></script>
+<script src="lib/quadtile-index.js"></script>
+<script src="lib/to-regex-range.js"></script>
 <script>
+    var MAX_ZOOM_LEVEL = 19;
 
     // Allow user to change style via the ?s=xxx URL parameter
     // Uses "osm-intl" as the default style
@@ -287,11 +290,43 @@
         return false;
     }
 
+    function printTileBanRegexes(tile, beforeZoom) {
+        var qidx = require('quadtile-index');
+        var toRegexRange = require('to-regex-range');
+        var zoom = map.getZoom();
+        var resultBox = document.getElementById('result');
+
+        var minIdx = qidx.xyToIndex(tile.x, tile.y);
+        var maxIdx = qidx.xyToIndex(tile.x, tile.y);
+        var xyMin;
+        var xyMax;
+
+        var result = [ `^/${style}/${zoom}/${tile.x}/${tile.y}` ];
+
+        for (++zoom; zoom < beforeZoom; zoom++) {
+            minIdx = minIdx * 4;
+            maxIdx = maxIdx * 4 + 3;
+            xyMin = qidx.indexToXY(minIdx);
+            xyMax = qidx.indexToXY(maxIdx);
+            result.push(`^/${style}/${zoom}/${toRegexRange(xyMin[0], xyMax[0])}/${toRegexRange(xyMin[1], xyMax[1])}`)
+        }
+
+        result.forEach(regex => resultBox.innerHTML += `<br>${regex}`);
+    }
+
     map.on('click', function(e) {
-        if (!e.originalEvent.ctrlKey && !e.originalEvent.altKey) return;
+        if (!(e.originalEvent.ctrlKey || e.originalEvent.altKey || e.originalEvent.shiftKey)) return;
         if (!e.latlng) return;
 
         var tile = map.project(e.latlng).divideBy(256).floor();
+
+        if (e.originalEvent.shiftKey) {
+            var beforeZoomEl = document.getElementById('beforeZoom');
+            var beforeZoom = (beforeZoomEl.value && beforeZoomEl.value.trim()) || map.getZoom() + 3;
+            printTileBanRegexes(tile, Math.min(beforeZoom, MAX_ZOOM_LEVEL + 1));
+            return;
+        }
+
         var req = {};
         addField(req, 'zoom', map.getZoom());
         addField(req, 'x', tile.x);


### PR DESCRIPTION
Adds new functionality to TileratorUI in which clicking on a tile while
holding the Shift key will add to the results window one or more regular
expresssions representing ranges of tile URLs to ban in Varnish. These can
then be used in place of the regular expressions representing a global
tile ban in a script such as https://phabricator.wikimedia.org/P7451.

Example:

 ^/osm-intl/6/18/24
 ^/osm-intl/7/36|37/48|49
 ^/osm-intl/8/7[2-5]/9[6-9]
 ^/osm-intl/9/14[4-9]|15[01]/19[2-9]
 [...]

Regular expressions will be provided per zoom level for the current tile
and all children up to (but not including) the value specified in beforeZ. 
If no beforeZ is specified, regexes will be provided for the current and
the next two zoom levels as a default.

This patch relies on two node modules: to-regex-range[1] and
Kartotherian's own quadtile-index.[2]  These could have been incorporated
in a couple of different ways: an internal route taking a tile index and
beforeZoom value could have been added and queried via an XmlHttpRequest;
or the modules could be converted to frontend scripts, exposed internally
through the server, and loaded directly in the admin interface page. This
implementation does the latter.  For this reason it depends on a related
change to kartotherian/server.

Bug: https://phabricator.wikimedia.org/T159977

[1] https://www.npmjs.com/package/to-regex-range
[2] https://www.npmjs.com/package/quadtile-index