### PR TITLE
Add an event-emitting facility

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -87,6 +87,15 @@ services:
       - "@kartotherian/tilelive-vector"
       - "@kartotherian/babel"
 
+      # URI for the eventlogging service (optional)
+      eventlogging_service_uri: http://localhost:8085/v1/events
+      # Sources for which tiles in shared cache should be invalidated on resource change (optional)
+      sources_to_invalidate:
+      - osm
+      - osm-intl
+      # Domain of tile server (if sending invalidation events)
+      tile_server_domain: maps.localhost
+
       # If true, do not enable admin interface
       daemonOnly: true
 

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -88,6 +88,15 @@ services:
       - tilelive-http
       - tilelive-file
 
+      # URI for the eventlogging service (optional)
+      eventlogging_service_uri: http://localhost:8085/v1/events
+      # Sources for which tiles in shared cache should be invalidated on resource change (optional)
+      sources_to_invalidate:
+      - osm
+      - osm-intl
+      # Domain of tile server (if sending invalidation events)
+      tile_server_domain: maps.localhost
+
       # If true, do not enable admin interface
       daemonOnly: false
 

--- a/config.ui.yaml
+++ b/config.ui.yaml
@@ -84,6 +84,15 @@ services:
       - "@kartotherian/tilelive-vector"
       - "@kartotherian/babel"
 
+      # URI for the eventlogging service (optional)
+      eventlogging_service_uri: http://localhost:8085/v1/events
+      # Sources for which tiles in shared cache should be invalidated on resource change (optional)
+      sources_to_invalidate:
+      - osm
+      - osm-intl
+      # Domain of tile server (if sending invalidation events)
+      tile_server_domain: maps.localhost
+
       # If true, do not enable admin interface
       daemonOnly: false
 

--- a/lib/EventService.js
+++ b/lib/EventService.js
@@ -16,11 +16,12 @@ function getResourceChangeEvent(resourceUri, domain) {
 }
 
 class EventService {
-  constructor(eventBusUri, domain, sources, logger) {
+  constructor(eventBusUri, domain, sources, logger, protocol = 'https') {
     this.eventBusUri = eventBusUri;
     this.domain = domain;
     this.sources = sources;
     this.logger = logger;
+    this.protocol = protocol;
 
     this.emitEvents = (events) => {
       P.try(() => preq.post({
@@ -34,7 +35,7 @@ class EventService {
     this.emitResourceChangeEvents = uris => this.emitEvents(uris.map(uri => getResourceChangeEvent(uri, this.domain)));
 
     this.notifyTileChanged = (z, x, y) => {
-      this.emitResourceChangeEvents(this.sources.map(s => `//${this.domain}/${s}/${z}/${x}/${y}.png`));
+      this.emitResourceChangeEvents(this.sources.map(s => `${this.protocol}://${this.domain}/${s}/${z}/${x}/${y}.png`));
     };
   }
 }

--- a/lib/EventService.js
+++ b/lib/EventService.js
@@ -1,0 +1,42 @@
+const P = require('bluebird');
+const preq = require('preq');
+const uuid = require('cassandra-uuid').TimeUuid;
+
+function getResourceChangeEvent(resourceUri, domain) {
+  return {
+    meta: {
+      topic: 'resource_change',
+      uri: resourceUri,
+      id: uuid.now().toString(),
+      dt: new Date().toISOString(),
+      domain,
+    },
+    tags: ['tilerator'],
+  };
+}
+
+class EventService {
+  constructor(eventBusUri, domain, sources, logger) {
+    this.eventBusUri = eventBusUri;
+    this.domain = domain;
+    this.sources = sources;
+    this.logger = logger;
+
+    this.emitEvents = (events) => {
+      P.try(() => preq.post({
+        uri: this.eventBusUri,
+        headers: { 'content-type': 'application/json' },
+        body: events,
+      })).catch(e => this.logger.log('error/events/emit', e)).thenReturn({ status: 200 });
+    };
+
+    // eslint-disable-next-line max-len
+    this.emitResourceChangeEvents = uris => this.emitEvents(uris.map(uri => getResourceChangeEvent(uri, this.domain)));
+
+    this.notifyTileChanged = (z, x, y) => {
+      this.emitResourceChangeEvents(this.sources.map(s => `//${this.domain}/${s}/${z}/${x}/${y}.png`));
+    };
+  }
+}
+
+module.exports = EventService;


### PR DESCRIPTION
Adds an EventService class with the initial purpose of emitting resource
change events to prompt tile invalidation in Varnish.  The resource change
events are formatted as specified in the relevant schema in
https://github.com/wikimedia/mediawiki-event-schemas, for example:

```
  {
    "meta": {
      "domain": "maps.localhost",
      "dt": "2018-08-29T21:17:34.361Z",
      "id": "f26d80a0-abd0-11e8-a2ca-c789637275fa",
      "schema_uri": "resource_change/1",
      "topic": "resource_change",
      "uri": "//maps.localhost/osm-intl/12/2074/1405.png"
    },
    "tags": [
      "tilerator"
    ]
  }
```

The event processing URI, tile server domain, and sources to invalidate
are to be specified (optionally) in the service configuration file.

Bug: https://phabricator.wikimedia.org/T109776