### PR TITLE
Update jobprocessor to support sending resource change events

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@kartotherian/substantial": "^0.0.10",
     "@kartotherian/osm-bright-source": "^1.0.1",
     "@kartotherian/osm-bright-style": "^4.0.1",
-    "@kartotherian/jobprocessor": "^0.0.18",
+    "@kartotherian/jobprocessor": "^1.0.0",
     "@kartotherian/tilelive-tmsource": "~1.0.0",
     "@mapbox/tilelive": "~5.12.2",
     "@mapbox/tilelive-bridge": "~3.1.0"
@@ -80,6 +80,7 @@
     "istanbul": "^0.4.3",
     "mocha": "^5.0.4",
     "mocha-lcov-reporter": "^1.2.0",
+    "nock": "^9.6.1",
     "swagger-router": "^0.4.2",
     "tilelive-file": "~0.0.3",
     "tilelive-http": "~0.13.0",

--- a/test/features/app/app.js
+++ b/test/features/app/app.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const preq = require('preq');
+const nock = require('nock');
 const wait = require('wait-as-promised');
 const assert = require('../../utils/assert.js');
 const server = require('../../utils/server.js');
@@ -46,6 +47,13 @@ describe('express app', function expressApp() {
   it('moves a tile from source to destination', () => {
     // ensure file doesn't exist yet
     deleteIfExist('test/filestore/6/33/22.png');
+
+    // Mock the eventlogging server to receive resource change events from jobprocessor
+    // (will log error output to the console if no request is received)
+    nock('http://localhost:8085')
+      .post('/v1/events')
+      .reply(200);
+
     return preq.post({
       uri: `${server.config.uri}add?generatorId=gen&storageId=file&zoom=6&x=33&y=22`,
     }).then((res) => {


### PR DESCRIPTION
Bumps the jobprocessor version to 1.0.0, which supports sending resource
change events.

Updates the test case 'moves a tile from source to destination' to account
for the resource change event being sent.

Bug: https://phabricator.wikimedia.org/T109776