### PR TITLE
Tilerator crash with Postgres Lock

### DIFF
--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -102,3 +102,7 @@ services:
       # If true, runs this instance without processing tiles
       # This could be good for queue management
       uiOnly: false
+
+      # Set different timeout for tile generation in case mapnik stuck on
+      # locked resource while reading Postgres
+      tileTimeOut: 90000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilerator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Map tiles pre-generation service",
   "main": "./app.js",
   "scripts": {
@@ -59,9 +59,9 @@
     "@kartotherian/layermixer": "^0.0.8",
     "@kartotherian/overzoom": "^0.0.16",
     "@kartotherian/substantial": "^0.0.10",
-    "@kartotherian/osm-bright-source": "^1.0.1",
+    "@kartotherian/osm-bright-source": "^1.0.2",
     "@kartotherian/osm-bright-style": "^4.0.1",
-    "@kartotherian/jobprocessor": "^1.0.0",
+    "@kartotherian/jobprocessor": "^1.0.1",
     "@kartotherian/tilelive-tmsource": "~1.0.0",
     "@mapbox/tilelive": "~5.12.2",
     "@mapbox/tilelive-bridge": "~3.1.0"

--- a/routes/tilerator.js
+++ b/routes/tilerator.js
@@ -145,7 +145,7 @@ function startup(app) {
           if (jobProcessor) {
             core.log('warn', 'Another handler is already running');
           }
-          jobProcessor = new JobProcessor(sources, job, core.metrics, queue, eventService);
+          jobProcessor = new JobProcessor(sources, job, core.metrics, queue, eventService, app.conf.tileTimeOut);
           return jobProcessor.runAsync();
         }).catch((err) => {
           core.metrics.increment('joberror');

--- a/routes/tilerator.js
+++ b/routes/tilerator.js
@@ -145,7 +145,14 @@ function startup(app) {
           if (jobProcessor) {
             core.log('warn', 'Another handler is already running');
           }
-          jobProcessor = new JobProcessor(sources, job, core.metrics, queue, eventService, app.conf.tileTimeOut);
+          jobProcessor = new JobProcessor(
+            sources,
+            job,
+            core.metrics,
+            queue,
+            eventService,
+            app.conf.tileTimeOut
+          );
           return jobProcessor.runAsync();
         }).catch((err) => {
           core.metrics.increment('joberror');


### PR DESCRIPTION
Adding tileTimeOut as a parameter for JobProcessor and in the
configuration as an example

Depends on https://github.com/kartotherian/jobprocessor/pull/6

Bug: [T204047](https://phabricator.wikimedia.org/T204047)